### PR TITLE
Use current dir as a target

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -1,6 +1,34 @@
 import * as path from 'path';
+import { writeFileSync } from 'fs';
 import { spawn } from 'child_process';
 import { binPath, green } from '../utils';
+
+const cwd = process.cwd();
+
+const es5Config = {
+  "importHelpers": true,
+  "noImplicitAny": true,
+  "removeComments": true,
+  "declaration": true,
+  "outDir": `${cwd}/dist/es5`,
+  "lib": ["dom", "es6"],
+  "target": "es5",
+  "jsx": "react",
+  "moduleResolution": "node"
+};
+
+const es2015Config = {
+  ...es5Config,
+  "outDir": `${cwd}/dist/es2015`,
+    "lib": ["dom", "es6"],
+    "module": "es2015",
+    "moduleResolution": "node"
+};
+
+const makeConfig = (options:any) => ({
+  "compilerOptions": options,
+  "include": [`${cwd}/src/**/*.ts`, `${cwd}/src/**/*.tsx`]
+});
 
 const tscBin = binPath('tsc');
 const buildES5 = (): Promise<void> => {
@@ -8,9 +36,10 @@ const buildES5 = (): Promise<void> => {
     green('Creating ES5 dist 🌟');
 
     const configPath = path.resolve(__dirname, '../../tsconfig.es5.json');
+    writeFileSync(configPath, JSON.stringify(makeConfig(es5Config), null, ' '));
     // NODE_ENV=production
     const subprocess = spawn(tscBin, ['-p', configPath], {
-      env: { ...process.env, FORCE_COLOR: true },
+      env: {...process.env, FORCE_COLOR: true},
       stdio: 'inherit'
     });
 
@@ -23,8 +52,9 @@ const buildES2015 = () => {
     green('Creating ES2015 dist 🌟🌟');
 
     const configPath = path.resolve(__dirname, '../../tsconfig.es2015.json');
+    writeFileSync(configPath, JSON.stringify(makeConfig(es2015Config), null, ' '));
     const subprocess = spawn(tscBin, ['-p', configPath], {
-      env: { ...process.env, FORCE_COLOR: true },
+      env: {...process.env, FORCE_COLOR: true},
       stdio: 'inherit'
     });
 

--- a/src/commands/publish/index.ts
+++ b/src/commands/publish/index.ts
@@ -1,5 +1,6 @@
 import * as webpack from 'webpack';
 import * as path from 'path';
+// @ts-ignore
 import * as ghpages from 'gh-pages';
 import { green, exec, createWebpackConf } from '../../utils';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,8 +28,5 @@
   },
   "include": [
     "bin"
-  ],
-  "files": [
-    "./typings/gh-pages.d.ts"
   ]
 }


### PR DESCRIPTION
Recently I've tried to use ts-react-toolbox in a monorepo, and it failed me :sadparrot:

### Problem
build script uses relative path, and it always refer to a one location - literally project root.

### Solution
generate `tsconfig` on the fly, using absolute paths from `process.cwd`, which reflect the project build script was called for.