### PR TITLE
fix: stop removing comments to preserve documentation

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -8,7 +8,7 @@ const cwd = process.cwd();
 const es5Config = {
   "importHelpers": true,
   "noImplicitAny": true,
-  "removeComments": true,
+  "removeComments": false,
   "declaration": true,
   "outDir": `${cwd}/dist/es5`,
   "lib": ["dom", "es6"],


### PR DESCRIPTION
Let's keep them, and make __jsdoc great again__!