### PR TITLE
Allow for using consumers jest config

### DIFF
--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -1,12 +1,19 @@
 import * as path from 'path';
 import { spawn } from 'child_process';
 import { binPath } from '../utils';
+import { checkFileExists } from '../utils/checkFileExists';
 
 const defaultArgs = ['--watch'];
 
 export const test = async (args: string[] = defaultArgs) => {
   const jestBin = binPath('jest');
-  const configPath = path.resolve(__dirname, '../../jest.config.js');
+
+  const upperJestPath = '../../../../jest.config.js';
+  const defaultJestPath = '../../jest.config.js';
+  const pathString = checkFileExists(upperJestPath)
+    ? upperJestPath
+    : defaultJestPath;
+  const configPath = path.resolve(__dirname, pathString);
 
   try {
     const subprocess = spawn(jestBin, ['-c', configPath, ...args], {

--- a/src/utils/checkFileExists.ts
+++ b/src/utils/checkFileExists.ts
@@ -1,0 +1,9 @@
+import { existsSync } from "fs";
+import path from 'path';
+
+export const checkFileExists = (resolutionPath: string) => {
+  if (existsSync(path.resolve(__dirname, resolutionPath))) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
This PR allows the the consumer of this repo to specify a `jest.config.js` file in the root of their own repo. If it is present then it will be used. Otherwise we fallback to the `jest.config.js` which is present in this package.

I've tested this using yalc and https://github.com/AdilBhayani/Date-time-convertor.